### PR TITLE
fix install - prepend tr with ctype locale

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ DATA_DIR="/var/$NAME"
 
 PORT=7999
 ADMIN_USERNAME='root'
-ADMIN_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 64)
+ADMIN_PASSWORD=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | head -c 64)
 
 mkdir -p $DATA_DIR
 mkdir $DATA_DIR/data


### PR DESCRIPTION
preventively set locale for _**tr**_ command if system uses one that could result in "Illegal byte sequence"